### PR TITLE
Update Tack shop to support 1.5-beta SWEM versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ run
 
 # Files from Forge MDK
 forge*changelog.txt
+
+
+# Local dependencies for testing
+libs

--- a/build.gradle
+++ b/build.gradle
@@ -128,9 +128,6 @@ repositories {
 
     // If you have mod jar dependencies in ./libs, you can declare them as a repository like so.
     // See https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:flat_dir_resolver
-    // flatDir {
-    //     dir 'libs'
-    // }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,7 +47,7 @@ mod_name=Tre's Tack Shop
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/
-mod_version=3.3.3--1.20.1
+mod_version=4.0.0--1.20.1
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/kyraltre/tretackshop/registry/AwardShopItems.java
+++ b/src/main/java/com/kyraltre/tretackshop/registry/AwardShopItems.java
@@ -11,6 +11,7 @@ import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries.Keys;
 import net.minecraftforge.registries.RegistryObject;
+import software.bernie.geckolib.core.object.Color;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -176,7 +177,7 @@ public class AwardShopItems {
                 () -> new AdventureLegWraps("adventure_leg_wraps_morpho", (new Item.Properties())
                         .stacksTo(64)));
         ADVENTURE_BRIDLE_MORPHO = REGISTRY.register("adventure_bridle_morpho",
-                () -> new AdventureBridleItem("adventure_bridle_morpho", "adventure_bridle_morpho", (new Item.Properties())
+                () -> new AdventureBridleItem("adventure_bridle_morpho", (new Item.Properties())
                         .stacksTo(16)));
         ADVENTURE_GIRTH_STRAP_MORPHO = REGISTRY.register("adventure_girth_strap_morpho",
                 () -> new AdventureGirthStrapItem("adventure_girth_strap_morpho", (new Item.Properties())
@@ -192,7 +193,7 @@ public class AwardShopItems {
                 () -> new WesternSaddleItem("western_saddle_morpho", (new Item.Properties())
                         .stacksTo(1)));
         WESTERN_BLANKET_MORPHO = REGISTRY.register("western_blanket_morpho",
-                () -> new WesternBlanketItem("western_blanket_morpho", (new Item.Properties())
+                () -> new WesternBlanketItem("western_blanket_morpho", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
         WESTERN_BREAST_COLLAR_MORPHO = REGISTRY.register("western_breast_collar_morpho",
                 () -> new WesternBreastCollarItem("western_breast_collar_morpho", (new Item.Properties())
@@ -204,14 +205,14 @@ public class AwardShopItems {
                 () -> new WesternBridleItem("western_bridle_morpho", (new Item.Properties())
                         .stacksTo(16)));
         WESTERN_GIRTH_STRAP_MORPHO = REGISTRY.register("western_girth_strap_morpho",
-                () -> new WesternGirthStrapItem("western_girth_strap_morpho", (new Item.Properties())
+                () -> new WesternGirthStrapItem("western_girth_strap_morpho", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         ENGLISH_SADDLE_MORPHO = REGISTRY.register("english_saddle_morpho",
                 () -> new EnglishSaddleItem("english_saddle_morpho", (new Item.Properties())
                         .stacksTo(1)));
         ENGLISH_BLANKET_MORPHO = REGISTRY.register("english_blanket_morpho",
-                () -> new EnglishBlanketItem("english_blanket_morpho", (new Item.Properties())
+                () -> new EnglishBlanketItem("english_blanket_morpho", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
         ENGLISH_BREAST_COLLAR_MORPHO = REGISTRY.register("english_breast_collar_morpho",
                 () -> new EnglishBreastCollar("english_breast_collar_morpho", (new Item.Properties())
@@ -223,19 +224,19 @@ public class AwardShopItems {
                 () -> new EnglishBridleItem("english_bridle_morpho", (new Item.Properties())
                         .stacksTo(16)));
         ENGLISH_GIRTH_STRAP_MORPHO = REGISTRY.register("english_girth_strap_morpho",
-                () -> new EnglishGirthStrap("english_girth_strap_morpho", (new Item.Properties())
+                () -> new EnglishGirthStrap("english_girth_strap_morpho", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         BITLESS_BRIDLE_MORPHO = REGISTRY.register("english_bridle_bitless_morpho",
                 () -> new EnglishBridleItem("english_bridle_bitless_morpho", (new Item.Properties())
                         .stacksTo(16)));
         BAREBACK_BLANKET_MORPHO = REGISTRY.register("bareback_blanket_morpho",
-                () -> new WesternBlanketItem("bareback_blanket_morpho", (new Item.Properties())
+                () -> new WesternBlanketItem("bareback_blanket_morpho", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         PASTURE_BLANKET_MORPHO = REGISTRY.register("pasture_blanket_morpho",
                 () -> new PastureBlanketItem(SWEMHorseArmorItem.HorseArmorTier.NONE, 0,
-                        "pasture_blanket_morpho", new Item.Properties()
+                        "pasture_blanket_morpho", Color.BLACK, new Item.Properties()
                         .stacksTo(16)));
         QUARTER_SHEET_MORPHO = REGISTRY.register("quarter_sheet_morpho",
                 () -> new AdventureBreastCollarItem("quarter_sheet_morpho", (new Item.Properties())
@@ -264,7 +265,7 @@ public class AwardShopItems {
                 () -> new AdventureLegWraps("adventure_leg_wraps_monarch", (new Item.Properties())
                         .stacksTo(64)));
         ADVENTURE_BRIDLE_MONARCH = REGISTRY.register("adventure_bridle_monarch",
-                () -> new AdventureBridleItem("adventure_bridle_monarch", "adventure_bridle_monarch", (new Item.Properties())
+                () -> new AdventureBridleItem("adventure_bridle_monarch", (new Item.Properties())
                         .stacksTo(16)));
         ADVENTURE_GIRTH_STRAP_MONARCH = REGISTRY.register("adventure_girth_strap_monarch",
                 () -> new AdventureGirthStrapItem("adventure_girth_strap_monarch", (new Item.Properties())
@@ -280,7 +281,7 @@ public class AwardShopItems {
                 () -> new WesternSaddleItem("western_saddle_monarch", (new Item.Properties())
                         .stacksTo(1)));
         WESTERN_BLANKET_MONARCH = REGISTRY.register("western_blanket_monarch",
-                () -> new WesternBlanketItem("western_blanket_monarch", (new Item.Properties())
+                () -> new WesternBlanketItem("western_blanket_monarch", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
         WESTERN_BREAST_COLLAR_MONARCH = REGISTRY.register("western_breast_collar_monarch",
                 () -> new WesternBreastCollarItem("western_breast_collar_monarch", (new Item.Properties())
@@ -292,14 +293,14 @@ public class AwardShopItems {
                 () -> new WesternBridleItem("western_bridle_monarch", (new Item.Properties())
                         .stacksTo(16)));
         WESTERN_GIRTH_STRAP_MONARCH = REGISTRY.register("western_girth_strap_monarch",
-                () -> new WesternGirthStrapItem("western_girth_strap_monarch", (new Item.Properties())
+                () -> new WesternGirthStrapItem("western_girth_strap_monarch", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         ENGLISH_SADDLE_MONARCH = REGISTRY.register("english_saddle_monarch",
                 () -> new EnglishSaddleItem("english_saddle_monarch", (new Item.Properties())
                         .stacksTo(1)));
         ENGLISH_BLANKET_MONARCH = REGISTRY.register("english_blanket_monarch",
-                () -> new EnglishBlanketItem("english_blanket_monarch", (new Item.Properties())
+                () -> new EnglishBlanketItem("english_blanket_monarch", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
         ENGLISH_BREAST_COLLAR_MONARCH = REGISTRY.register("english_breast_collar_monarch",
                 () -> new EnglishBreastCollar("english_breast_collar_monarch", (new Item.Properties())
@@ -311,19 +312,19 @@ public class AwardShopItems {
                 () -> new EnglishBridleItem("english_bridle_monarch", (new Item.Properties())
                         .stacksTo(16)));
         ENGLISH_GIRTH_STRAP_MONARCH = REGISTRY.register("english_girth_strap_monarch",
-                () -> new EnglishGirthStrap("english_girth_strap_monarch", (new Item.Properties())
+                () -> new EnglishGirthStrap("english_girth_strap_monarch", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         BITLESS_BRIDLE_MONARCH = REGISTRY.register("english_bridle_bitless_monarch",
                 () -> new EnglishBridleItem("english_bridle_bitless_monarch", (new Item.Properties())
                         .stacksTo(16)));
         BAREBACK_BLANKET_MONARCH = REGISTRY.register("bareback_blanket_monarch",
-                () -> new WesternBlanketItem("bareback_blanket_monarch", (new Item.Properties())
+                () -> new WesternBlanketItem("bareback_blanket_monarch", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         PASTURE_BLANKET_MONARCH = REGISTRY.register("pasture_blanket_monarch",
                 () -> new PastureBlanketItem(SWEMHorseArmorItem.HorseArmorTier.NONE, 0,
-                        "pasture_blanket_monarch", new Item.Properties()
+                        "pasture_blanket_monarch", Color.BLACK, new Item.Properties()
                         .stacksTo(16)));
         QUARTER_SHEET_MONARCH = REGISTRY.register("quarter_sheet_monarch",
                 () -> new AdventureBreastCollarItem("quarter_sheet_monarch", (new Item.Properties())
@@ -387,7 +388,7 @@ public class AwardShopItems {
                             .stacksTo(64))
             ));
             AWARD_ADVENTURE_BRIDLES .add(REGISTRY.register("award_adventure_bridle_"+ counter,
-                    () -> new AdventureBridleItem("award_adventure_bridle_"+ counter, "award_adventure_"+ counter, (new Item.Properties())
+                    () -> new AdventureBridleItem("award_adventure_bridle_"+ counter, (new Item.Properties())
                             .stacksTo(16))
             ));
             AWARD_ADVENTURE_GIRTH_STRAPS .add(REGISTRY.register("award_adventure_girth_strap_"+ counter,
@@ -418,7 +419,7 @@ public class AwardShopItems {
                             .stacksTo(16))
             ));
             AWARD_WESTERN_BLANKETS.add(REGISTRY.register("award_western_blanket_" + counter,
-                    () -> new WesternBlanketItem("award_western_blanket_" + counter, (new Item.Properties())
+                    () -> new WesternBlanketItem("award_western_blanket_" + counter, Color.BLACK, (new Item.Properties())
                             .stacksTo(16))
             ));
             AWARD_WESTERN_BREAST_COLLARS.add(REGISTRY.register("award_western_breast_collar_" + counter,
@@ -434,7 +435,7 @@ public class AwardShopItems {
                             .stacksTo(16))
             ));
             AWARD_WESTERN_GIRTH_STRAPS.add(REGISTRY.register("award_western_girth_strap_" + counter,
-                    () -> new WesternGirthStrapItem("award_western_girth_strap_" + counter, (new Item.Properties())
+                    () -> new WesternGirthStrapItem("award_western_girth_strap_" + counter, Color.BLACK, (new Item.Properties())
                             .stacksTo(16))
             ));
         }
@@ -447,7 +448,7 @@ public class AwardShopItems {
                             .stacksTo(16))
             ));
             AWARD_ENGLISH_BLANKETS.add(REGISTRY.register("award_english_blanket_" + counter,
-                    () -> new EnglishBlanketItem("award_english_blanket_" + counter, (new Item.Properties())
+                    () -> new EnglishBlanketItem("award_english_blanket_" + counter, Color.BLACK, (new Item.Properties())
                             .stacksTo(16))
             ));
             AWARD_ENGLISH_BREAST_COLLARS.add(REGISTRY.register("award_english_breast_collar_" + counter,
@@ -463,7 +464,7 @@ public class AwardShopItems {
                             .stacksTo(16))
             ));
             AWARD_ENGLISH_GIRTH_STRAPS.add(REGISTRY.register("award_english_girth_strap_" + counter,
-                    () -> new EnglishGirthStrap("award_english_girth_strap_" + counter, (new Item.Properties())
+                    () -> new EnglishGirthStrap("award_english_girth_strap_" + counter, Color.BLACK, (new Item.Properties())
                             .stacksTo(16))
             ));
         }
@@ -485,12 +486,12 @@ public class AwardShopItems {
             ));
             AWARD_PASTURE_BLANKETS.add(REGISTRY.register("award_pasture_blanket_" + counter,
                     () -> new PastureBlanketItem(SWEMHorseArmorItem.HorseArmorTier.NONE, 0,
-                            "award_pasture_blanket_" + counter, (new Item.Properties())
+                            "award_pasture_blanket_" + counter, Color.BLACK, (new Item.Properties())
                             .stacksTo(16))
             ));
             AWARD_PASTURE_BLANKETS_ARMORED.add(REGISTRY.register("award_pasture_blanket_" + counter + "_armored",
                     () -> new PastureBlanketItem(SWEMHorseArmorItem.HorseArmorTier.DIAMOND, 37,
-                            "award_pasture_blanket_" + counter + "_armored", (new Item.Properties())
+                            "award_pasture_blanket_" + counter + "_armored", Color.BLACK, (new Item.Properties())
                             .stacksTo(16))
             ));
         }

--- a/src/main/java/com/kyraltre/tretackshop/registry/TackShopItems.java
+++ b/src/main/java/com/kyraltre/tretackshop/registry/TackShopItems.java
@@ -15,6 +15,7 @@ import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.RegistryObject;
 import net.minecraftforge.registries.ForgeRegistries.Keys;
+import software.bernie.geckolib.core.object.Color;
 
 public class TackShopItems {
     public static final DeferredRegister<Item> REGISTRY;
@@ -165,13 +166,13 @@ public class TackShopItems {
 
         // ONE OFF TACK
         PELHAM_BRIDLE_BLACK = REGISTRY.register("pelham_bridle_black",
-                () -> new AdventureBridleItem("pelham_bridle_black", "pelham_black", (new Item.Properties())
+                () -> new AdventureBridleItem("pelham_bridle_black", (new Item.Properties())
                         .stacksTo(16)));
         PELHAM_BRIDLE_BROWN = REGISTRY.register("pelham_bridle_brown",
-                () -> new AdventureBridleItem("pelham_bridle_brown", "pelham_brown", (new Item.Properties())
+                () -> new AdventureBridleItem("pelham_bridle_brown", (new Item.Properties())
                         .stacksTo(16)));
         MOON_BRIDLE_DOUBLE = REGISTRY.register("moon_bridle_double",
-                () -> new AdventureBridleItem("moon_bridle_double", "moon_double", (new Item.Properties())
+                () -> new AdventureBridleItem("moon_bridle_double", (new Item.Properties())
                         .stacksTo(16)));
         MEDIEVAL_BRIDLE_BLACK = REGISTRY.register("medieval_bridle_black",
                 () -> new EnglishBridleItem("medieval_bridle_black", (new Item.Properties())
@@ -186,10 +187,10 @@ public class TackShopItems {
                 () -> new WesternSaddleItem("bareback_saddle_black", (new Item.Properties())
                         .stacksTo(1)));
         BAREBACK_BLANKET = REGISTRY.register("bareback_blanket",
-                () -> new WesternBlanketItem("bareback_blanket", (new Item.Properties())
+                () -> new WesternBlanketItem("bareback_blanket", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
         BAREBACK_GIRTH_STRAP = REGISTRY.register("bareback_girth_strap",
-                () -> new WesternGirthStrapItem("bareback_girth_strap", (new Item.Properties())
+                () -> new WesternGirthStrapItem("bareback_girth_strap", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         BITLESS_BRIDLE_BROWN = REGISTRY.register("english_bridle_bitless_brown",
@@ -199,7 +200,7 @@ public class TackShopItems {
                 () -> new WesternSaddleItem("bareback_saddle_brown", (new Item.Properties())
                         .stacksTo(1)));
         BAREBACK_GIRTH_STRAP_BROWN = REGISTRY.register("bareback_girth_strap_brown",
-                () -> new WesternGirthStrapItem("bareback_girth_strap_brown", (new Item.Properties())
+                () -> new WesternGirthStrapItem("bareback_girth_strap_brown", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         BITLESS_BRIDLE_BEIGE = REGISTRY.register("english_bridle_bitless_beige",
@@ -209,7 +210,7 @@ public class TackShopItems {
                 () -> new WesternSaddleItem("bareback_saddle_beige", (new Item.Properties())
                         .stacksTo(1)));
         BAREBACK_GIRTH_STRAP_BEIGE = REGISTRY.register("bareback_girth_strap_beige",
-                () -> new WesternGirthStrapItem("bareback_girth_strap_beige", (new Item.Properties())
+                () -> new WesternGirthStrapItem("bareback_girth_strap_beige", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         BITLESS_BRIDLE_WHITE = REGISTRY.register("english_bridle_bitless_white",
@@ -219,17 +220,17 @@ public class TackShopItems {
                 () -> new WesternSaddleItem("bareback_saddle", (new Item.Properties())
                         .stacksTo(1)));
         BAREBACK_GIRTH_STRAP_WHITE = REGISTRY.register("bareback_girth_strap_white",
-                () -> new WesternGirthStrapItem("bareback_girth_strap_white", (new Item.Properties())
+                () -> new WesternGirthStrapItem("bareback_girth_strap_white", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         DRESSAGE_SADDLE = REGISTRY.register("dressage_saddle",
                 () -> new WesternSaddleItem("dressage_saddle", (new Item.Properties())
                         .stacksTo(1)));
         DRESSAGE_BLANKET = REGISTRY.register("dressage_blanket",
-                () -> new WesternBlanketItem("dressage_blanket", (new Item.Properties())
+                () -> new WesternBlanketItem("dressage_blanket", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
         DRESSAGE_GIRTH_STRAP = REGISTRY.register("dressage_girth_strap",
-                () -> new EnglishGirthStrap("dressage_girth_strap", (new Item.Properties())
+                () -> new EnglishGirthStrap("dressage_girth_strap", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         RACING_SADDLE_BROWN = REGISTRY.register("racing_saddle_brown",
@@ -239,7 +240,7 @@ public class TackShopItems {
                 () -> new EnglishSaddleItem("racing_saddle_black", (new Item.Properties())
                         .stacksTo(1)));
         HUNTER_BLANKET = REGISTRY.register("hunter_blanket",
-                () -> new EnglishBlanketItem("hunter_blanket", (new Item.Properties())
+                () -> new EnglishBlanketItem("hunter_blanket", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
 
@@ -261,7 +262,7 @@ public class TackShopItems {
                 () -> new AdventureLegWraps("adventure_leg_wraps_rainbow", (new Item.Properties())
                          .stacksTo(64)));
         ADVENTURE_BRIDLE_RAINBOW = REGISTRY.register("adventure_bridle_rainbow",
-                () -> new AdventureBridleItem("adventure_bridle_rainbow", "adventure_bridle_rainbow", (new Item.Properties())
+                () -> new AdventureBridleItem("adventure_bridle_rainbow",  (new Item.Properties())
                         .stacksTo(16)));
         ADVENTURE_GIRTH_STRAP_RAINBOW = REGISTRY.register("adventure_girth_strap_rainbow",
                 () -> new AdventureGirthStrapItem("adventure_girth_strap_rainbow", (new Item.Properties())
@@ -279,7 +280,7 @@ public class TackShopItems {
                 () -> new WesternSaddleItem("western_saddle_rainbow", (new Item.Properties())
                          .stacksTo(1)));
         WESTERN_BLANKET_RAINBOW =  REGISTRY.register("western_blanket_rainbow",
-                () -> new WesternBlanketItem("western_blanket_rainbow", (new Item.Properties())
+                () -> new WesternBlanketItem("western_blanket_rainbow", Color.BLACK, (new Item.Properties())
                          .stacksTo(16)));
         WESTERN_BREAST_COLLAR_RAINBOW =  REGISTRY.register("western_breast_collar_rainbow",
                 () -> new WesternBreastCollarItem("western_breast_collar_rainbow", (new Item.Properties())
@@ -291,14 +292,14 @@ public class TackShopItems {
                 () -> new WesternBridleItem("western_bridle_rainbow", (new Item.Properties())
                         .stacksTo(16)));
         WESTERN_GIRTH_STRAP_RAINBOW = REGISTRY.register("western_girth_strap_rainbow",
-                () -> new WesternGirthStrapItem("western_girth_strap_rainbow", (new Item.Properties())
+                () -> new WesternGirthStrapItem("western_girth_strap_rainbow", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         ENGLISH_SADDLE_RAINBOW =  REGISTRY.register("english_saddle_rainbow",
                 () -> new EnglishSaddleItem("english_saddle_rainbow", (new Item.Properties())
                          .stacksTo(1)));
         ENGLISH_BLANKET_RAINBOW =  REGISTRY.register("english_blanket_rainbow",
-                () -> new EnglishBlanketItem("english_blanket_rainbow", (new Item.Properties())
+                () -> new EnglishBlanketItem("english_blanket_rainbow", Color.BLACK, (new Item.Properties())
                          .stacksTo(16)));
         ENGLISH_BREAST_COLLAR_RAINBOW =  REGISTRY.register("english_breast_collar_rainbow",
                 () -> new EnglishBreastCollar("english_breast_collar_rainbow", (new Item.Properties())
@@ -310,22 +311,22 @@ public class TackShopItems {
                 () -> new EnglishBridleItem("english_bridle_rainbow", (new Item.Properties())
                         .stacksTo(16)));
         ENGLISH_GIRTH_STRAP_RAINBOW = REGISTRY.register("english_girth_strap_rainbow",
-                () -> new EnglishGirthStrap("english_girth_strap_rainbow", (new Item.Properties())
+                () -> new EnglishGirthStrap("english_girth_strap_rainbow", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
         CLOTH_BITLESS_BRIDLE_RAINBOW = REGISTRY.register("cloth_bitless_bridle_rainbow",
                 () -> new EnglishBridleItem("cloth_bitless_bridle_rainbow", (new Item.Properties())
                         .stacksTo(16)));
         BAREBACK_BLANKET_RAINBOW = REGISTRY.register("bareback_blanket_rainbow",
-                () -> new WesternBlanketItem("bareback_blanket_rainbow", (new Item.Properties())
+                () -> new WesternBlanketItem("bareback_blanket_rainbow", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         PASTURE_BLANKET_RAINBOW =  REGISTRY.register("pasture_blanket_rainbow",
                 () -> new PastureBlanketItem(SWEMHorseArmorItem.HorseArmorTier.NONE, 0,
-                        "pasture_blanket_rainbow", new Item.Properties()
+                        "pasture_blanket_rainbow", Color.BLACK, new Item.Properties()
                          .stacksTo(16)));
         PASTURE_BLANKET_RAINBOW_ARMORED =  REGISTRY.register("pasture_blanket_rainbow_armored",
                 () -> new PastureBlanketItem(SWEMHorseArmorItem.HorseArmorTier.DIAMOND, 37,
-                        "pasture_blanket_rainbow_armored", (new Item.Properties())
+                        "pasture_blanket_rainbow_armored", Color.BLACK, (new Item.Properties())
                          .stacksTo(16)));
         QUARTER_SHEET_BLACK_RAINBOW = REGISTRY.register("quarter_sheet_black_rainbow",
                 () -> new AdventureBreastCollarItem("quarter_sheet_black_rainbow", (new Item.Properties())
@@ -348,7 +349,7 @@ public class TackShopItems {
                 () -> new AdventureLegWraps("adventure_leg_wraps_trans", (new Item.Properties())
                         .stacksTo(64)));
         ADVENTURE_BRIDLE_TRANS = REGISTRY.register("adventure_bridle_trans",
-                () -> new AdventureBridleItem("adventure_bridle_trans", "adventure_trans", (new Item.Properties())
+                () -> new AdventureBridleItem("adventure_bridle_trans", (new Item.Properties())
                         .stacksTo(16)));
         ADVENTURE_GIRTH_STRAP_TRANS = REGISTRY.register("adventure_girth_strap_trans",
                 () -> new AdventureGirthStrapItem("adventure_girth_strap_trans", (new Item.Properties())
@@ -358,26 +359,26 @@ public class TackShopItems {
                 () -> new WesternSaddleItem("western_saddle_trans", (new Item.Properties())
                         .stacksTo(1)));
         WESTERN_BLANKET_TRANS = REGISTRY.register("western_blanket_trans",
-                () -> new WesternBlanketItem("western_blanket_trans", (new Item.Properties())
+                () -> new WesternBlanketItem("western_blanket_trans", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
         WESTERN_BRIDLE_TRANS = REGISTRY.register("western_bridle_trans",
                 () -> new WesternBridleItem("western_bridle_trans", (new Item.Properties())
                         .stacksTo(16)));
         WESTERN_GIRTH_STRAP_TRANS = REGISTRY.register("western_girth_strap_trans",
-                () -> new WesternGirthStrapItem("western_girth_strap_trans", (new Item.Properties())
+                () -> new WesternGirthStrapItem("western_girth_strap_trans", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         ENGLISH_SADDLE_TRANS = REGISTRY.register("english_saddle_trans",
                 () -> new EnglishSaddleItem("english_saddle_trans", (new Item.Properties())
                         .stacksTo(1)));
         ENGLISH_BLANKET_TRANS = REGISTRY.register("english_blanket_trans",
-                () -> new EnglishBlanketItem("english_blanket_trans", (new Item.Properties())
+                () -> new EnglishBlanketItem("english_blanket_trans", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
         ENGLISH_BRIDLE_TRANS = REGISTRY.register("english_bridle_trans",
                 () -> new EnglishBridleItem("english_bridle_trans", (new Item.Properties())
                         .stacksTo(16)));
         ENGLISH_GIRTH_STRAP_TRANS = REGISTRY.register("english_girth_strap_trans",
-                () -> new EnglishGirthStrap("english_girth_strap_trans", (new Item.Properties())
+                () -> new EnglishGirthStrap("english_girth_strap_trans", Color.BLACK, (new Item.Properties())
                         .stacksTo(16)));
 
         // Craftable Numbered Tack Items -- 12 Count Items
@@ -450,7 +451,7 @@ public class TackShopItems {
                              .stacksTo(64))
             ));
             ADVENTURE_BRIDLES.add(REGISTRY.register("adventure_bridle_" + counter,
-                    () -> new AdventureBridleItem("adventure_bridle_" + counter, "adventure_" + counter, (new Item.Properties())
+                    () -> new AdventureBridleItem("adventure_bridle_" + counter, (new Item.Properties())
                             .stacksTo(16))
             ));
             ADVENTURE_GIRTH_STRAPS.add(REGISTRY.register("adventure_girth_strap_" + counter,
@@ -471,7 +472,7 @@ public class TackShopItems {
                              .stacksTo(1))
             ));
             WESTERN_BLANKETS.add( REGISTRY.register("western_blanket_" + counter, () ->
-                    new WesternBlanketItem("western_blanket_" + counter, (new Item.Properties())
+                    new WesternBlanketItem("western_blanket_" + counter, Color.BLACK, (new Item.Properties())
                              .stacksTo(16))
             ));
             WESTERN_BREAST_COLLARS.add( REGISTRY.register("western_breast_collar_" + counter, () ->
@@ -487,7 +488,7 @@ public class TackShopItems {
                             .stacksTo(16))
             ));
             WESTERN_GIRTH_STRAPS.add(REGISTRY.register("western_girth_strap_" + counter,
-                    () -> new WesternGirthStrapItem("western_girth_strap_" + counter, (new Item.Properties())
+                    () -> new WesternGirthStrapItem("western_girth_strap_" + counter, Color.BLACK, (new Item.Properties())
                             .stacksTo(16))
             ));
 
@@ -496,7 +497,7 @@ public class TackShopItems {
                              .stacksTo(1))
             ));
             ENGLISH_BLANKETS.add( REGISTRY.register("english_blanket_" + counter, () ->
-                    new EnglishBlanketItem("english_blanket_" + counter, (new Item.Properties())
+                    new EnglishBlanketItem("english_blanket_" + counter, Color.BLACK, (new Item.Properties())
                              .stacksTo(16))
             ));
             ENGLISH_BREAST_COLLARS.add( REGISTRY.register("english_breast_collar_" + counter, () ->
@@ -512,7 +513,7 @@ public class TackShopItems {
                             .stacksTo(16))
             ));
             ENGLISH_GIRTH_STRAPS.add(REGISTRY.register("english_girth_strap_" + counter,
-                    () -> new EnglishGirthStrap("english_girth_strap_" + counter, (new Item.Properties())
+                    () -> new EnglishGirthStrap("english_girth_strap_" + counter, Color.BLACK, (new Item.Properties())
                             .stacksTo(16))
             ));
 
@@ -525,7 +526,7 @@ public class TackShopItems {
                             .stacksTo(16))
             ));
             CLOTH_GIRTH_STRAPS.add(REGISTRY.register("cloth_girth_strap_" + counter,
-                    () -> new EnglishGirthStrap("cloth_girth_strap_" + counter, (new Item.Properties())
+                    () -> new EnglishGirthStrap("cloth_girth_strap_" + counter, Color.BLACK, (new Item.Properties())
                             .stacksTo(16))
             ));
 
@@ -534,18 +535,18 @@ public class TackShopItems {
                             .stacksTo(16))
             ));
             BAREBACK_BLANKETS.add(REGISTRY.register("bareback_blanket_" + counter, () ->
-                    new WesternBlanketItem("bareback_blanket_" + counter, (new Item.Properties())
+                    new WesternBlanketItem("bareback_blanket_" + counter, Color.BLACK, (new Item.Properties())
                             .stacksTo(16))
             ));
             
             PASTURE_BLANKETS.add( REGISTRY.register("pasture_blanket_" + counter, () ->
                     new PastureBlanketItem(SWEMHorseArmorItem.HorseArmorTier.NONE, 0,
-                            "pasture_blanket_" + counter, (new Item.Properties())
+                            "pasture_blanket_" + counter, Color.BLACK, (new Item.Properties())
                              .stacksTo(16))
             ));
             PASTURE_BLANKETS_ARMORED.add( REGISTRY.register("pasture_blanket_" + counter + "_armored", () ->
                     new PastureBlanketItem(SWEMHorseArmorItem.HorseArmorTier.DIAMOND, 37,
-                            "pasture_blanket_" + counter + "_armored", (new Item.Properties())
+                            "pasture_blanket_" + counter + "_armored", Color.BLACK, (new Item.Properties())
                              .stacksTo(16))
             ));
             QUARTER_SHEETS_NUMBERED.add(REGISTRY.register("quarter_sheet_" + counter, () ->
@@ -581,7 +582,7 @@ public class TackShopItems {
                             .stacksTo(16))
             ));
             BAREBACK_BLANKETS_DYED.add(REGISTRY.register("bareback_blanket_" + color.getName(), () ->
-                    new WesternBlanketItem("bareback_blanket_" + color.getName(), (new Item.Properties())
+                    new WesternBlanketItem("bareback_blanket_" + color.getName(), Color.BLACK, (new Item.Properties())
                             .stacksTo(16))
             ));
             FLYMASKS.add( REGISTRY.register("flymask_" + color.getName(), () ->

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -65,7 +65,7 @@ description='''${mod_description}'''
 [[dependencies.tretackshop]] #our parent mod
     modId="swem"
     mandatory=true
-    versionRange="[1.3.0,)"
+    versionRange="[1.5,),[1.5-beta-,)"
     ordering="AFTER"
     side="BOTH"
 


### PR DESCRIPTION
Here is a PR that fixes TTS for 1.20.1 when targeting 1.5-beta and 1.5 versions.

This mod version is locked to 1.5 and 1.5-beta versions through the mod.toml.

This will not be backwards compatible, since it was not forwards compatible, but again should be locked and stop loading with the mod checker inside of forge.

Feel free to update the version if that makes more sense, hope it helps. Such a great mod with a good amount of time spent (and 100k+ downloads) shouldn't just die. :D